### PR TITLE
Arreglo de errores de estilos para affiliate-card

### DIFF
--- a/src/components/layout/modules/affiliate-card.module.scss
+++ b/src/components/layout/modules/affiliate-card.module.scss
@@ -1,7 +1,9 @@
 @import "../../../assets/css/colors";
 @import "../../../assets/css/breakpoints";
+@import "../../UI/modules/card.module.scss";
 
 .AffiliateCard {
+  @extend .Card;
   background-color: transparent;
   box-shadow: none;
   width: 100%;


### PR DESCRIPTION
 Commit inicial para mejorar los estilos de affiliate-card.
 Observo que en la versión en vivo de la rama develop, los archivos de estilos minificados están declarando los archivos en el orden que no se espera. Pruebo este commit para ver si me da el resultado deseado.