### PR TITLE
Arreglo de la activación del slider modal con doble click

### DIFF
--- a/src/components/UI/modals/slider-modal.component.js
+++ b/src/components/UI/modals/slider-modal.component.js
@@ -1,12 +1,10 @@
 import { Dialog, DialogContent,Slide } from "@material-ui/core";
 import { Close } from "@material-ui/icons";
-import React, { useEffect } from "react";
+import React from "react";
 // REDUX
 import { useDispatch, useSelector } from "react-redux";
-// REACT ROUTER
-import { useLocation } from "react-router-dom";
 
-// REDUX ACTIONS
+// REDUX ACTION
 import { closeSliderModal } from "../../../store/actions";
 // CLASSES
 import classes from "../modules/modals/g-modal.module.scss";
@@ -15,16 +13,10 @@ const Transition = React.forwardRef((props, ref) => <Slide direction={window.scr
 
 export const SliderModal = ({ title, children }) => {
   const dispatch = useDispatch(),
-    location = useLocation(),
     isOpen = useSelector((state) => state.Modal.isSliderOpen);
 
   // HANDLERS
   const closeSliderModalHandler = () => dispatch(closeSliderModal());
-
-  // EFFECTS
-  useEffect(() => {
-    dispatch(closeSliderModal());
-  }, [location, dispatch]);
 
   return (
     <Dialog

--- a/src/components/layout/navigation/profile-navigation.component.js
+++ b/src/components/layout/navigation/profile-navigation.component.js
@@ -25,7 +25,7 @@ const ProfileNavigation = () => {
   const closeSliderModalHandler = () => dispatch(closeSliderModal());
 
   const logoutHandler = () => {
-    closeSliderModalHandler();
+    setTimeout(() => closeSliderModalHandler(), 5000);
     dispatch(logoutInit());
   };
 

--- a/src/components/layout/navigation/profile-navigation.component.js
+++ b/src/components/layout/navigation/profile-navigation.component.js
@@ -10,8 +10,8 @@ import Logout from "../../../assets/images/icons/logout.svg";
 import VerifyIdentity from "../../../assets/images/icons/verify-identity.svg";
 // HOOK
 import { useUserData } from "../../../shared/hooks/useProfileInfo";
-// REDUX ACTION
-import { logoutInit } from "../../../store/actions";
+// REDUX ACTIONS
+import { closeSliderModal, logoutInit } from "../../../store/actions";
 // CLASSES
 import classes from "../modules/profile-nav.module.scss";
 // COMPONENT
@@ -21,6 +21,13 @@ const ProfileNavigation = () => {
   const dispatch = useDispatch(),
     user = useSelector((state) => state.Auth.user),
     { Avatar } = useUserData(user);
+
+  const closeSliderModalHandler = () => dispatch(closeSliderModal());
+
+  const logoutHandler = () => {
+    closeSliderModalHandler();
+    dispatch(logoutInit());
+  };
 
   return (
     <div className={classes.ProfileNavigation}>
@@ -35,15 +42,15 @@ const ProfileNavigation = () => {
       </div>
       <nav>
         <ul>
-          <NavItem label="Datos básicos" icon={Profile} link="/my-profile" />
-          {user.level < 3 && <NavItem label="Verificar identidad" icon={VerifyIdentity} link="/my-profile/verify-identity" />}
-          <NavItem label="Datos Adicionales" icon={AdditionalInfo} link="/my-profile/additionals" />
-          <a href="https://instakash.net/faq" target="_blank" rel="noopener noreferrer" className={classes.NavItem}>
+          <NavItem label="Datos básicos" icon={Profile} link="/my-profile" onClick={closeSliderModalHandler} />
+          {user.level < 3 && <NavItem label="Verificar identidad" icon={VerifyIdentity} link="/my-profile/verify-identity" onClick={closeSliderModalHandler} />}
+          <NavItem label="Datos Adicionales" icon={AdditionalInfo} link="/my-profile/additionals" onClick={closeSliderModalHandler} />
+          <a href="https://instakash.net/faq" target="_blank" rel="noopener noreferrer" className={classes.NavItem} onClick={closeSliderModalHandler}>
             <img src={Help} alt="centro-de-ayuda" width={26} className="mr-3" />
             Centro de ayuda
           </a>
         </ul>
-        <button className="flex items-center" onClick={() => dispatch(logoutInit())}>
+        <button className="flex items-center" onClick={logoutHandler}>
           <img src={Logout} alt="cerrar-sesión" width={20} className="mr-3" />
           Cerrar sesión
         </button>


### PR DESCRIPTION
 Finalmente he arreglado la activación a doble click del slider modal. **_Sin embargo_**, me gustaría que me dieras tu opinión del setTimeout en el logoutHandler del archivo "profile-navigation.component.js". Probé dejando que provoque el cierre del slider modal sin setTimeout y se ve al instante cómo se cierra. Por lo tanto, queda como en espera en la pantalla de Inicio hasta que redirija a la pantalla de la ruta **/signin**.
 Aplico el setTimeout con 5 segundos porque considero que es un tiempo razonable para esperar a que la aplicación redirija a la ruta **/signin**, no se vea el cierre instántaneo del slider modal como sucede con los otros links y tras volver a iniciar sesión de nuevo aparece oculto el slider modal.